### PR TITLE
Add Firestore Integration for User Collections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { auth, signInWithGoogle, logout, saveCollection, getCollection } from "@/lib/firebase";
-import { onAuthStateChanged, User } from "firebase/auth";
+import { useEffect, useState } from "react"
+import { auth, signInWithGoogle, logout, saveCollection, getCollection } from "@/lib/firebase"
+import { onAuthStateChanged, User } from "firebase/auth"
 
-const COLLECTION_ID = "fishCollection"; // Example collection type
+const COLLECTION_ID = "fishCollection"
 
-// Default collection items
+// test collection items
 const DEFAULT_COLLECTION = {
   "Rare Fish": false,
   "Exotic Gem": false,
@@ -14,48 +14,45 @@ const DEFAULT_COLLECTION = {
 };
 
 export default function Home() {
-  const [user, setUser] = useState<User | null>(null);
-  const [collection, setCollection] = useState<Record<string, boolean>>(DEFAULT_COLLECTION);
-  const [loading, setLoading] = useState(true); // ✅ Add loading state
+  const [user, setUser] = useState<User | null>(null)
+  const [collection, setCollection] = useState<Record<string, boolean>>(DEFAULT_COLLECTION)
+  const [loading, setLoading] = useState(true) //loading state
 
-  // Listen for Auth Changes
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-      setUser(currentUser);
+      setUser(currentUser)
 
       if (currentUser) {
-        setLoading(true); // ✅ Show loading until data is fetched
+        setLoading(true)
 
-        const savedCollection = await getCollection(currentUser.uid, COLLECTION_ID);
+        const savedCollection = await getCollection(currentUser.uid, COLLECTION_ID)
 
         if (savedCollection && Object.keys(savedCollection).length > 0) {
-          setCollection(savedCollection);
-        } else {
-          // ✅ Save default collection if no Firestore data exists
-          await saveCollection(currentUser.uid, COLLECTION_ID, DEFAULT_COLLECTION);
-          setCollection(DEFAULT_COLLECTION);
+          setCollection(savedCollection)
+        } else { //saves toggled selections if no data currently exists
+          await saveCollection(currentUser.uid, COLLECTION_ID, DEFAULT_COLLECTION)
+          setCollection(DEFAULT_COLLECTION)
         }
 
-        setLoading(false); // ✅ Stop loading
+        setLoading(false)
       } else {
-        setCollection(DEFAULT_COLLECTION); // Reset to default when logged out
-        setLoading(false);
+        setCollection(DEFAULT_COLLECTION)
+        setLoading(false)
       }
     });
 
-    return () => unsubscribe();
-  }, []);
+    return () => unsubscribe()
+  }, [])
 
-  // Toggle Item and Save to Firestore
   const toggleItem = async (item: string) => {
-    if (!user) return;
+    if (!user) return
 
-    const updatedCollection = { ...collection, [item]: !collection[item] };
-    setCollection(updatedCollection);
-    await saveCollection(user.uid, COLLECTION_ID, updatedCollection);
+    const updatedCollection = { ...collection, [item]: !collection[item] }
+    setCollection(updatedCollection)
+    await saveCollection(user.uid, COLLECTION_ID, updatedCollection)
   };
 
-  if (loading) return <p className="text-center text-gray-500">Loading...</p>; // ✅ Show loading message
+  if (loading) return <p className="text-center text-gray-500">Loading...</p>
 
   return (
     <div className="min-h-screen bg-gray-100 p-8">
@@ -88,5 +85,5 @@ export default function Home() {
         </button>
       )}
     </div>
-  );
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,61 @@
-"use client"
+"use client";
 
-import { useEffect, useState } from "react"
-import { db, auth, signInWithGoogle, logout } from "@/lib/firebase"
-import { collection, getDocs } from "firebase/firestore"
-import { onAuthStateChanged, User } from "firebase/auth"
+import { useEffect, useState } from "react";
+import { auth, signInWithGoogle, logout, saveCollection, getCollection } from "@/lib/firebase";
+import { onAuthStateChanged, User } from "firebase/auth";
+
+const COLLECTION_ID = "fishCollection"; // Example collection type
+
+// Default collection items
+const DEFAULT_COLLECTION = {
+  "Rare Fish": false,
+  "Exotic Gem": false,
+  "Unique Plant": false,
+};
 
 export default function Home() {
+  const [user, setUser] = useState<User | null>(null);
+  const [collection, setCollection] = useState<Record<string, boolean>>(DEFAULT_COLLECTION);
+  const [loading, setLoading] = useState(true); // ✅ Add loading state
 
-  const [user, setUser] = useState<User | null>(null)
-
+  // Listen for Auth Changes
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser)
-    })
+    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+      setUser(currentUser);
+
+      if (currentUser) {
+        setLoading(true); // ✅ Show loading until data is fetched
+
+        const savedCollection = await getCollection(currentUser.uid, COLLECTION_ID);
+
+        if (savedCollection && Object.keys(savedCollection).length > 0) {
+          setCollection(savedCollection);
+        } else {
+          // ✅ Save default collection if no Firestore data exists
+          await saveCollection(currentUser.uid, COLLECTION_ID, DEFAULT_COLLECTION);
+          setCollection(DEFAULT_COLLECTION);
+        }
+
+        setLoading(false); // ✅ Stop loading
+      } else {
+        setCollection(DEFAULT_COLLECTION); // Reset to default when logged out
+        setLoading(false);
+      }
+    });
 
     return () => unsubscribe();
-  }, [])
+  }, []);
+
+  // Toggle Item and Save to Firestore
+  const toggleItem = async (item: string) => {
+    if (!user) return;
+
+    const updatedCollection = { ...collection, [item]: !collection[item] };
+    setCollection(updatedCollection);
+    await saveCollection(user.uid, COLLECTION_ID, updatedCollection);
+  };
+
+  if (loading) return <p className="text-center text-gray-500">Loading...</p>; // ✅ Show loading message
 
   return (
     <div className="min-h-screen bg-gray-100 p-8">
@@ -27,6 +67,20 @@ export default function Home() {
           <button onClick={logout} className="bg-red-500 text-white p-2 rounded-md">
             Sign Out
           </button>
+
+          <ul className="mt-4 space-y-2">
+            {Object.keys(collection).map((item) => (
+              <li
+                key={item}
+                className={`p-3 border rounded-lg cursor-pointer ${
+                  collection[item] ? "bg-green-300" : "bg-white"
+                }`}
+                onClick={() => toggleItem(item)}
+              >
+                {item} {collection[item] ? "✅" : ""}
+              </li>
+            ))}
+          </ul>
         </div>
       ) : (
         <button onClick={signInWithGoogle} className="bg-blue-500 text-white p-2 rounded-md">
@@ -34,5 +88,5 @@ export default function Home() {
         </button>
       )}
     </div>
-  )
+  );
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,6 @@
 import { initializeApp } from "firebase/app"
-import { getFirestore } from "firebase/firestore"
+import { getFirestore, doc, setDoc, getDoc, updateDoc } from "firebase/firestore"
 import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from "firebase/auth"
-// import { error } from "console";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -10,7 +9,7 @@ const firebaseConfig = {
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+}
 
 
 const app = initializeApp(firebaseConfig)
@@ -36,4 +35,15 @@ const logout = async () => {
   }
 }
 
-export { db, auth, signInWithGoogle, logout }
+const saveCollection = async (userId: string, collectionId: string, updatedCollection: Record<string, boolean>) => {
+  const userRef = doc(db, "users", userId, "collections", collectionId )
+  await setDoc(userRef, updatedCollection, { merge: true })
+}
+
+const getCollection = async (userId: string, collectionId: string) => {
+  const userRef = doc(db, "users", userId, "collections", collectionId)
+  const docSnap = await getDoc(userRef)
+  return docSnap.exists() ? docSnap.data() : {}
+}
+
+export { db, auth, signInWithGoogle, logout, saveCollection, getCollection, }


### PR DESCRIPTION
Already users could sign in w/ Google SSO, so this PR does:

1. See their collection progress persist across sessions (logged out, logged in, refreshed)
2. Toggle collection items, and the data is saved in Firestore
3. Automatically get a default collection if they have no saved data
4. Avoid flickering issues with a loading state


Firestore structure: Collections are stored per user `(users/{userId}/collections/{collectionId})`
Authentication: Uses Firebase Auth (`onAuthStateChange`d to track logins)
Prevents UI flickering with a loading state
Uses `setCollection()` to make UI updates feel instant